### PR TITLE
Adjust maze initialization timing

### DIFF
--- a/src/components/PlayScreen/PlayScreen.jsx
+++ b/src/components/PlayScreen/PlayScreen.jsx
@@ -39,6 +39,10 @@ export default function PlayScreen({ speedMode, mode }) {
   const [visited, setVisited] = useState(() => new Set());
   const [pathSet, setPathSet] = useState(() => new Set());
   const [wave, setWave] = useState({ x: 0, y: 0, key: 0 });
+  const [mazeRefreshKey, setMazeRefreshKey] = useState(0);
+
+  const startRef = useRef(start);
+  const targetRef = useRef(target);
 
   const visitDelay = SPEED_PRESETS[speedMode]?.VISIT ?? SPEED_PRESETS.Normal.VISIT;
   const pathDelay = SPEED_PRESETS[speedMode]?.PATH ?? SPEED_PRESETS.Normal.PATH;
@@ -62,10 +66,25 @@ export default function PlayScreen({ speedMode, mode }) {
   }, [clearAlgorithmPaint]);
 
   useEffect(() => {
+    startRef.current = start;
+  }, [start]);
+
+  useEffect(() => {
+    targetRef.current = target;
+  }, [target]);
+
+  useEffect(() => {
     if (mode === 'maze') {
-      setWalls(generateMaze(GRID_ROWS, GRID_COLS, start, target));
+      setWalls(generateMaze(GRID_ROWS, GRID_COLS, startRef.current, targetRef.current));
     }
-  }, [mode, start, target]);
+  }, [mode, mazeRefreshKey]);
+
+  useEffect(() => {
+    updateWalls((draft) => {
+      draft.delete(key(start.row, start.col));
+      draft.delete(key(target.row, target.col));
+    });
+  }, [start, target, updateWalls]);
 
   useEffect(() => {
     if (!isPointerDown) {
@@ -197,7 +216,6 @@ export default function PlayScreen({ speedMode, mode }) {
       if (dragging === 'start') {
         if (!(cell.row === target.row && cell.col === target.col)) {
           setStart({ row: cell.row, col: cell.col });
-          updateWalls((draft) => draft.delete(key(cell.row, cell.col)));
         }
         return;
       }
@@ -205,7 +223,6 @@ export default function PlayScreen({ speedMode, mode }) {
       if (dragging === 'target') {
         if (!(cell.row === start.row && cell.col === start.col)) {
           setTarget({ row: cell.row, col: cell.col });
-          updateWalls((draft) => draft.delete(key(cell.row, cell.col)));
         }
         return;
       }
@@ -351,7 +368,10 @@ export default function PlayScreen({ speedMode, mode }) {
       <ControlBar
         onRun={runAlgorithm}
         onReset={resetBoard}
-        onMaze={() => setWalls(generateMaze(GRID_ROWS, GRID_COLS, start, target))}
+        onMaze={() => {
+          clearAlgorithmPaint();
+          setMazeRefreshKey((value) => value + 1);
+        }}
       />
     </motion.main>
   );

--- a/src/components/PlayScreen/PlayScreen.jsx
+++ b/src/components/PlayScreen/PlayScreen.jsx
@@ -73,11 +73,21 @@ export default function PlayScreen({ speedMode, mode }) {
     targetRef.current = target;
   }, [target]);
 
+  const updateWalls = useCallback((updater) => {
+    setWalls((prev) => {
+      const next = new Set(prev);
+      updater(next);
+      return next;
+    });
+  }, []);
+
   useEffect(() => {
-    if (mode === 'maze') {
-      setWalls(generateMaze(GRID_ROWS, GRID_COLS, startRef.current, targetRef.current));
+    if (mode !== 'maze' && mazeRefreshKey === 0) {
+      return;
     }
-  }, [mode, mazeRefreshKey]);
+
+    setWalls(generateMaze(GRID_ROWS, GRID_COLS, startRef.current, targetRef.current));
+  }, [mazeRefreshKey, mode]);
 
   useEffect(() => {
     updateWalls((draft) => {
@@ -115,14 +125,6 @@ export default function PlayScreen({ speedMode, mode }) {
     }),
     [gridSize.cell],
   );
-
-  const updateWalls = useCallback((updater) => {
-    setWalls((prev) => {
-      const next = new Set(prev);
-      updater(next);
-      return next;
-    });
-  }, []);
 
   const eventToCell = useCallback(
     (event) => {


### PR DESCRIPTION
## Summary
- decouple maze generation from start/target changes by tracking mode transitions and explicit refreshes
- keep start and target cells clear of walls when they move using the shared wall updater
- reuse the maze refresh hook from the Maze button while clearing any prior algorithm paint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d86a80ae6c8326b9c9d7524c726611