### PR TITLE
Refactor pathfinder grid cells into memoized component

### DIFF
--- a/src/components/PlayScreen/PathfinderCell.jsx
+++ b/src/components/PlayScreen/PathfinderCell.jsx
@@ -1,0 +1,31 @@
+import { memo } from 'react';
+import { motion } from 'framer-motion';
+
+const BASE_CLASSNAME = 'w-full h-full';
+const PATH_CLASSNAME = 'w-full h-full path-shimmer';
+
+function PathfinderCell({
+  path,
+  style,
+  initialVariant,
+  animateVariant,
+  transition,
+}) {
+  return (
+    <motion.div
+      className={path ? PATH_CLASSNAME : BASE_CLASSNAME}
+      style={style}
+      initial={initialVariant}
+      animate={animateVariant}
+      transition={transition}
+    />
+  );
+}
+
+export default memo(PathfinderCell, (prev, next) =>
+  prev.visited === next.visited &&
+  prev.path === next.path &&
+  prev.wall === next.wall &&
+  prev.isStart === next.isStart &&
+  prev.isTarget === next.isTarget,
+);


### PR DESCRIPTION
## Summary
- extract a dedicated `PathfinderCell` component wrapped in `React.memo` for grid rendering
- track wall/visited/path changes with version counters and shared style objects so unchanged cells retain memoization
- render the board grid via memoized cells to keep animations focused on the tiles that actually update

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8d645bb2883269f14920b5ea38a0f