### PR TITLE
Fix grid cell memo dependencies for algorithm array refs

### DIFF
--- a/src/components/PlayScreen/PlayScreen.jsx
+++ b/src/components/PlayScreen/PlayScreen.jsx
@@ -482,7 +482,7 @@ export default function PlayScreen({ speedMode, mode }) {
     }
     return cells;
                             
-  }, [cellStyles, cellTransitions, cellVariants, pathSet, start, target, visited, walls]);
+  }, [cellStyles, cellTransitions, cellVariants, pathVersion, start, target, visitedVersion, walls]);
 
   const waveDiameter = useMemo(() => {
     const { width = 0, height = 0 } = gridSize;


### PR DESCRIPTION
## Summary
- update the grid cell memoization to depend on the version counters that wrap the typed algorithm arrays

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68de4e804ed083269b50de7ab09ee05d